### PR TITLE
Implements first native driver call (decline_offer).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,12 @@
 name = "mesos"
 version = "0.1.0"
 authors = ["Connor Doyle <connor@mesosphere.io>"]
-# links = "mesos"
 build = "build.rs"
 
 [build-dependencies]
 gcc = "0.3"
 
 [dependencies]
-lazy_static = "0.1.14"
 libc = "0.1"
 
 [dependencies.protobuf]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ _Note: this project is not ready to use for anything._
 
 ## Building `mesos-rust`
 
+This project depends on Rust version 1.3.
+
 Using [cargo](http://crates.io):
 
 ```

--- a/resources/mesos-c/scheduler_driver.cpp
+++ b/resources/mesos-c/scheduler_driver.cpp
@@ -375,14 +375,10 @@ void CScheduler::resourceOffers(
     return;
   }
 
-  vector<std::string> encodedOffers;
-  vector<ProtobufObj> offersObj;
+  vector<std::string> encodedOffers(offers.size());
+  vector<ProtobufObj> offersObj(offers.size());
   for (size_t i = 0; i < offers.size(); i++) {
-    std::string encodedOffer;
-    ProtobufObj offerObj =
-      utils::serialize<const Offer>(offers[i], encodedOffer);
-
-    offersObj.push_back(offerObj);
+    offersObj[i] = utils::serialize<const Offer>(offers[i], encodedOffers[i]);
   }
 
   callbacks.resourceOffersCallBack(payload, &offersObj[0], offersObj.size());

--- a/src/bin/test_scheduler.rs
+++ b/src/bin/test_scheduler.rs
@@ -11,13 +11,14 @@ struct MyScheduler;
 impl Scheduler for MyScheduler {
     fn registered(
         &self,
-        _: &SchedulerDriver,
+        driver: &SchedulerDriver,
         framework_id: &proto::FrameworkID,
         master_info: &proto::MasterInfo) {
 
         println!("MyScheduler::registered");
         println!("framework_id: {:?}", framework_id);
         println!("master_info: {:?}", master_info);
+        driver.print_debug_info();
     }
 
     fn reregistered(
@@ -36,7 +37,6 @@ impl Scheduler for MyScheduler {
 
         println!("MyScheduler::resource_offers");
         println!("Received [{}] offers", offers.len());
-
         driver.print_debug_info();
 
         for offer in offers {
@@ -130,7 +130,7 @@ fn main() -> () {
 
     let mut driver = MesosSchedulerDriver::new(
         &scheduler,
-        framework_info,
+        &framework_info,
         "localhost:5050".to_string(),
     );
 

--- a/src/bin/test_scheduler.rs
+++ b/src/bin/test_scheduler.rs
@@ -31,13 +31,16 @@ impl Scheduler for MyScheduler {
 
     fn resource_offers(
         &self,
-        _: &SchedulerDriver,
+        driver: &SchedulerDriver,
         offers: Vec<proto::Offer>) {
 
         println!("MyScheduler::resource_offers");
         println!("Received [{}] offers", offers.len());
         for offer in offers {
-            println!("  Offer: [{:?}]", offer);
+            println!("Declining  offer: [{:?}]", offer);
+            driver.decline_offer(
+                offer.get_id(),
+                &proto::Filters::new());
         }
     }
 

--- a/src/bin/test_scheduler.rs
+++ b/src/bin/test_scheduler.rs
@@ -11,14 +11,13 @@ struct MyScheduler;
 impl Scheduler for MyScheduler {
     fn registered(
         &self,
-        driver: &SchedulerDriver,
+        _: &SchedulerDriver,
         framework_id: &proto::FrameworkID,
         master_info: &proto::MasterInfo) {
 
         println!("MyScheduler::registered");
         println!("framework_id: {:?}", framework_id);
         println!("master_info: {:?}", master_info);
-        driver.print_debug_info();
     }
 
     fn reregistered(
@@ -37,7 +36,6 @@ impl Scheduler for MyScheduler {
 
         println!("MyScheduler::resource_offers");
         println!("Received [{}] offers", offers.len());
-        driver.print_debug_info();
 
         for offer in offers {
             println!("Declining  offer: [{:?}]", offer);

--- a/src/bin/test_scheduler.rs
+++ b/src/bin/test_scheduler.rs
@@ -36,6 +36,9 @@ impl Scheduler for MyScheduler {
 
         println!("MyScheduler::resource_offers");
         println!("Received [{}] offers", offers.len());
+
+        driver.print_debug_info();
+
         for offer in offers {
             println!("Declining  offer: [{:?}]", offer);
             driver.decline_offer(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate protobuf;
-#[macro_use] extern crate lazy_static;
 extern crate libc;
 
 // pub mod http;

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -6,102 +6,45 @@ mod tests;
 use libc::{c_char, c_void, size_t};
 use proto;
 use scheduler::{Scheduler, SchedulerDriver};
+use std::boxed::Box;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::option::Option;
-use std::ptr;
 use std::slice;
 use std::str;
-use std::sync::RwLock;
 
-// HACK. A 128 bit type to hold Rust trait references.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[repr(C)]
-struct TraitPtr(u64, u64);
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-struct SchedulerPtr(pub TraitPtr);
-unsafe impl Send for SchedulerPtr {}
-unsafe impl Sync for SchedulerPtr {}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-struct SchedulerDriverPtr(pub *mut c_void);
-unsafe impl Send for SchedulerDriverPtr {}
-unsafe impl Sync for SchedulerDriverPtr {}
-
-lazy_static! {
-    // HACK.
-    //
-    // TODO(CD): Clean this up (using a lookup and synchronization
-    // barriers) to make it possible for a single process to activate
-    // multiple scheduler drivers simultaneously.
-    static ref SCHEDULER_PTR: RwLock<Option<SchedulerPtr>> =
-        RwLock::new(None);
-
-    static ref SCHEDULER_DRIVER_PTR: RwLock<Option<SchedulerDriverPtr>> =
-        RwLock::new(None);
-}
-
-fn delegate<L, T>(lambda: L) -> T
-    where L : Fn(&Scheduler, &MesosSchedulerDriver) -> T {
-
-    let scheduler: &Scheduler = unsafe {
-        let SchedulerPtr(raw) =
-            SCHEDULER_PTR.read()
-                .unwrap()  // Unwrap lock acquisition result.
-                .unwrap(); // Unwrap option.
-        mem::transmute(raw)
-    };
-
-    let scheduler_driver: &MesosSchedulerDriver = unsafe {
-        let SchedulerDriverPtr(raw) =
-            SCHEDULER_DRIVER_PTR.read()
-                .unwrap()  // Unwrap lock acquisition result.
-                .unwrap(); // Unwrap option.
-        mem::transmute(raw)
-    };
-
-    lambda(scheduler, scheduler_driver)
-}
-
 pub struct MesosSchedulerDriver<'a> {
     scheduler: &'a Scheduler,
-    framework_info: proto::FrameworkInfo,
+    framework_info: &'a proto::FrameworkInfo,
     master: String,
     native_ptr_pair: Option<mesos_c::SchedulerPtrPair>,
 }
 
 impl<'a> MesosSchedulerDriver<'a> {
 
-    pub fn new(
-        scheduler: &Scheduler,
-        framework_info: proto::FrameworkInfo,
+    pub fn new<'d>(
+        scheduler: &'d Scheduler,
+        framework_info: &'d proto::FrameworkInfo,
         master: String
-    ) -> &MesosSchedulerDriver {
+    ) -> Box<MesosSchedulerDriver<'d>> {
 
-        let driver = &MesosSchedulerDriver {
-            scheduler: scheduler,
-            framework_info: framework_info,
-            master: master,
-            native_ptr_pair: None,
-        };
+        let mut driver = Box::new(
+            MesosSchedulerDriver {
+                scheduler: scheduler,
+                framework_info: framework_info,
+                master: master,
+                native_ptr_pair: None,
+            }
+        );
 
-        // Limited scope for lock acquisition
-        {
-            // Save pointers to be used when constructing C funtions that
-            // delegate to the Rust scheduler implementation.
-            let mut sched_ptr = SCHEDULER_PTR.write().unwrap();
-            *sched_ptr = Some(unsafe { mem::transmute(scheduler) });
-
-            let mut driver_ptr = SCHEDULER_DRIVER_PTR.write().unwrap();
-            *driver_ptr = Some(unsafe { mem::transmute(driver) });
-        }
-
-        println!("Just wrote into driver_ptr...");
-
-        delegate(|_, d| { d.print_debug_info(); });
+        // Save pointers to be used when constructing C funtions that
+        // delegate to the Rust scheduler implementation.
+        driver.native_ptr_pair = Some(mesos_c::SchedulerPtrPair {
+            driver: unsafe { mem::transmute(&driver) },
+            scheduler: unsafe { mem::transmute(&scheduler) },
+        });
 
         driver
     }
@@ -109,38 +52,46 @@ impl<'a> MesosSchedulerDriver<'a> {
     fn create_callbacks(&self) -> mesos_c::SchedulerCallBacks {
 
         extern "C" fn wrapped_registered_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_framework_id: *mut mesos_c::ProtobufObj,
             native_master_info: *mut mesos_c::ProtobufObj
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let framework_id = &mut proto::FrameworkID::new();
             mesos_c::ProtobufObj::merge(native_framework_id, framework_id);
 
             let master_info = &mut proto::MasterInfo::new();
             mesos_c::ProtobufObj::merge(native_master_info, master_info);
 
-            delegate(|scheduler, driver| {
-                scheduler.registered(driver, &framework_id, master_info);
-            });
+            driver.scheduler.registered(driver, &framework_id, master_info);
         }
 
         extern "C" fn wrapped_reregistered_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_master_info: *mut mesos_c::ProtobufObj
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let master_info = &mut proto::MasterInfo::new();
             mesos_c::ProtobufObj::merge(native_master_info, master_info);
 
-            delegate(|scheduler, driver| {
-                scheduler.reregistered(driver, master_info);
-            });
+            driver.scheduler.reregistered(driver, master_info);
         }
 
         extern "C" fn wrapped_resource_offers_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_offers: *mut mesos_c::ProtobufObj,
             native_num_offers: size_t
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let num_offers = native_num_offers as usize;
 
             let pbs = unsafe {
@@ -157,49 +108,57 @@ impl<'a> MesosSchedulerDriver<'a> {
                 offers.push(offer);
             }
 
-            delegate(|scheduler, driver| {
-                scheduler.resource_offers(driver, offers.clone());
-            });
+            driver.scheduler.resource_offers(driver, offers.clone());
         }
 
         extern "C" fn wrapped_status_update_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_task_status: *mut mesos_c::ProtobufObj
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let task_status = &mut proto::TaskStatus::new();
             mesos_c::ProtobufObj::merge(native_task_status, task_status);
 
-            delegate(|scheduler, driver| {
-                scheduler.status_update(driver, task_status);
-            });
+            driver.scheduler.status_update(driver, task_status);
         }
 
         extern "C" fn wrapped_disconnected_callback(
-            _: mesos_c::SchedulerDriverPtr
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
         ) -> () {
-            delegate(|scheduler, driver| {
-                scheduler.disconnected(driver);
-            });
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
+            driver.scheduler.disconnected(driver);
         }
 
         extern "C" fn wrapped_offer_rescinded_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_offer_id: *mut mesos_c::ProtobufObj
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let offer_id = &mut proto::OfferID::new();
             mesos_c::ProtobufObj::merge(native_offer_id, offer_id);
 
-            delegate(|scheduler, driver| {
-                scheduler.offer_rescinded(driver, offer_id);
-            });
+            driver.scheduler.offer_rescinded(driver, offer_id);
         }
 
         extern "C" fn wrapped_framework_message_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_executor_id: *mut mesos_c::ProtobufObj,
             native_slave_id: *mut mesos_c::ProtobufObj,
             native_data: *const c_char
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let executor_id = &mut proto::ExecutorID::new();
             mesos_c::ProtobufObj::merge(native_executor_id, executor_id);
 
@@ -214,32 +173,36 @@ impl<'a> MesosSchedulerDriver<'a> {
                 .unwrap()
                 .to_string();
 
-            delegate(|scheduler, driver| {
-                scheduler.framework_message(driver,
-                                            executor_id,
-                                            slave_id,
-                                            &data);
-            });
+            driver.scheduler.framework_message(driver,
+                                               executor_id,
+                                               slave_id,
+                                               &data);
         }
 
         extern "C" fn wrapped_slave_lost_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_slave_id: *mut mesos_c::ProtobufObj
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let slave_id = &mut proto::SlaveID::new();
             mesos_c::ProtobufObj::merge(native_slave_id, slave_id);
 
-            delegate(|scheduler, driver| {
-                scheduler.slave_lost(driver, slave_id);
-            });
+            driver.scheduler.slave_lost(driver, slave_id);
         }
 
         extern "C" fn wrapped_executor_lost_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_executor_id: *mut mesos_c::ProtobufObj,
             native_slave_id: *mut mesos_c::ProtobufObj,
             native_status: ::libc::c_int
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let executor_id = &mut proto::ExecutorID::new();
             mesos_c::ProtobufObj::merge(native_executor_id, executor_id);
 
@@ -248,15 +211,18 @@ impl<'a> MesosSchedulerDriver<'a> {
 
             let status = native_status as i32;
 
-            delegate(|scheduler, driver| {
-                scheduler.executor_lost(driver, executor_id, slave_id, status);
-            });
+            driver.scheduler.executor_lost(
+                driver, executor_id, slave_id, status);
         }
 
         extern "C" fn wrapped_error_callback(
-            _: mesos_c::SchedulerDriverPtr,
+            native_scheduler_driver: mesos_c::SchedulerDriverPtr,
             native_message: *const c_char
         ) -> () {
+            let driver: &MesosSchedulerDriver = unsafe {
+                mem::transmute(native_scheduler_driver)
+            };
+
             let message_slice = unsafe {
                 CStr::from_ptr(native_message).to_bytes()
             };
@@ -265,9 +231,7 @@ impl<'a> MesosSchedulerDriver<'a> {
                 .unwrap()
                 .to_string();
 
-            delegate(|scheduler, driver| {
-                scheduler.error(driver, &message);
-            });
+            driver.scheduler.error(driver, &message);
         }
 
         mesos_c::SchedulerCallBacks {
@@ -289,45 +253,48 @@ impl<'a> MesosSchedulerDriver<'a> {
 impl<'a> SchedulerDriver for MesosSchedulerDriver<'a> {
 
     fn print_debug_info(&self) {
-        println!("framework_info: [{:?}]", self.framework_info);
+        println!("MesosSchedulerDriver:");
+        println!("  framework_info: [{:?}]", self.framework_info);
+        println!("  master: [{:?}]", self.master);
+        println!("  native_ptr_pair.is_some(): [{:?}]",
+            self.native_ptr_pair.is_some());
     }
 
     fn run(&mut self) -> i32 {
-        assert!(self.native_ptr_pair.is_none());
 
         let callbacks: *mut mesos_c::SchedulerCallBacks =
             &mut self.create_callbacks();
 
-        let native_payload: *mut c_void = ptr::null_mut();
+        let native_payload: *mut c_void = unsafe {
+            mem::transmute(&self.clone())
+        };
 
         // lifetime of pb_data must exceed native_framework_info
         let pb_data = &mut vec![];
 
         let native_framework_info =
             &mut mesos_c::ProtobufObj::from_message(
-                &self.framework_info,
+                self.framework_info,
                 pb_data);
 
         let native_master = CString::new(self.master.clone()).unwrap();
 
-        let scheduler_ptr_pair = unsafe {
+        let native_ptr_pair = unsafe {
             mesos_c::scheduler_init(callbacks,
                 native_payload,
                 native_framework_info as *mut mesos_c::ProtobufObj,
                 native_master.as_ptr() as *const i8)
         };
 
-        self.native_ptr_pair = Some(scheduler_ptr_pair);
-
         println!("Starting scheduler driver");
         let scheduler_status = unsafe{
-            mesos_c::scheduler_start(scheduler_ptr_pair.driver)
+            mesos_c::scheduler_start(native_ptr_pair.driver)
         };
         println!("scheduler_status: [{}]", scheduler_status);
 
         println!("Joining scheduler driver");
         let scheduler_status = unsafe{
-            mesos_c::scheduler_join(scheduler_ptr_pair.driver)
+            mesos_c::scheduler_join(native_ptr_pair.driver)
         };
         println!("scheduler_status: [{}]", scheduler_status);
 
@@ -339,24 +306,27 @@ impl<'a> SchedulerDriver for MesosSchedulerDriver<'a> {
         offer_id: &proto::OfferID,
         filters: &proto::Filters) -> i32 {
 
+        println!("MesosSchedulerDriver::decline_offer");
+        self.print_debug_info();
+
         assert!(self.native_ptr_pair.is_some());
-        let scheduler_ptr_pair = self.native_ptr_pair.unwrap();
+        let native_driver = self.native_ptr_pair.unwrap().driver;
 
         let offer_id_data = &mut vec![];
-        let mut native_offer_id = mesos_c::ProtobufObj::from_message(
+        let native_offer_id = &mut mesos_c::ProtobufObj::from_message(
             offer_id,
             offer_id_data);
 
         let filters_data = &mut vec![];
-        let mut native_filters = mesos_c::ProtobufObj::from_message(
+        let native_filters = &mut mesos_c::ProtobufObj::from_message(
             filters,
             filters_data);
 
         let scheduler_status = unsafe {
             mesos_c::scheduler_declineOffer(
-                scheduler_ptr_pair.driver,
-                &mut native_offer_id,
-                &mut native_filters)
+                native_driver,
+                native_offer_id as *mut mesos_c::ProtobufObj,
+                native_filters as *mut mesos_c::ProtobufObj)
         };
 
         scheduler_status

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -323,4 +323,31 @@ impl<'a> SchedulerDriver for MesosSchedulerDriver<'a> {
         scheduler_status
     }
 
+    fn decline_offer(
+        &self,
+        offer_id: &proto::OfferID,
+        filters: &proto::Filters) -> i32 {
+
+        assert!(self.native_ptr_pair.is_some());
+        let scheduler_ptr_pair = self.native_ptr_pair.unwrap();
+
+        let offer_id_data = &mut vec![];
+        let mut native_offer_id = mesos_c::ProtobufObj::from_message(
+            offer_id,
+            offer_id_data);
+
+        let filters_data = &mut vec![];
+        let mut native_filters = mesos_c::ProtobufObj::from_message(
+            filters,
+            filters_data);
+
+        let scheduler_status = unsafe {
+            mesos_c::scheduler_declineOffer(
+                scheduler_ptr_pair.driver,
+                &mut native_offer_id,
+                &mut native_filters)
+        };
+
+        scheduler_status
+    }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -59,4 +59,9 @@ pub trait Scheduler {
 
 pub trait SchedulerDriver {
     fn run(&mut self) -> i32;
+
+    fn decline_offer(
+        &self,
+        offer_id: &proto::OfferID,
+        filters: &proto::Filters) -> i32;
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -58,6 +58,8 @@ pub trait Scheduler {
 }
 
 pub trait SchedulerDriver {
+    fn print_debug_info(&self) -> ();
+
     fn run(&mut self) -> i32;
 
     fn decline_offer(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -58,7 +58,6 @@ pub trait Scheduler {
 }
 
 pub trait SchedulerDriver {
-    fn print_debug_info(&self) -> ();
 
     fn run(&mut self) -> i32;
 


### PR DESCRIPTION
`MesosSchedulerDriver::decline_offer` works now!
Required an unsafe mutable reborrow to gain access to the correct raw pointer.

Fixes #8.
