### PR TITLE
First pass at `launch_tasks` scheduler driver call.

### DIFF
--- a/src/bin/test_scheduler.rs
+++ b/src/bin/test_scheduler.rs
@@ -37,10 +37,37 @@ impl Scheduler for MyScheduler {
         println!("MyScheduler::resource_offers");
         println!("Received [{}] offers", offers.len());
 
+        // for offer in offers {
+        //     println!("Declining  offer: [{:?}]", offer);
+        //     driver.decline_offer(
+        //         offer.get_id(),
+        //         &proto::Filters::new());
+        // }
+
         for offer in offers {
-            println!("Declining  offer: [{:?}]", offer);
-            driver.decline_offer(
+            println!("Launching a task on offer: [{:?}]", offer);
+            let mut task = proto::TaskInfo::new();
+
+            task.set_name("mesos-rust-task".to_string());
+
+            let mut task_id = proto::TaskID::new();
+            task_id.set_value(offer.get_id().get_value().to_string());
+            task.set_task_id(task_id);
+
+            let mut slave_id = proto::SlaveID::new();
+            slave_id.set_value(offer.get_slave_id().get_value().to_string());
+            task.set_slave_id(slave_id);
+
+            task.set_resources(offer.clone().take_resources());
+
+            let mut command = proto::CommandInfo::new();
+            command.set_shell(true);
+            command.set_value("env && sleep 10".to_string());
+            task.set_command(command);
+
+            driver.launch_tasks(
                 offer.get_id(),
+                &vec![&task],
                 &proto::Filters::new());
         }
     }

--- a/src/native/mesos_c.rs
+++ b/src/native/mesos_c.rs
@@ -27,6 +27,10 @@ impl ProtobufObj {
         data: &mut Vec<u8>
     ) -> ProtobufObj {
         message.write_to_vec(data).unwrap();
+        ProtobufObj::from_vec(data)
+    }
+
+    pub fn from_vec(data: &mut Vec<u8>) -> ProtobufObj {
         ProtobufObj {
             data: data.as_ptr() as *mut c_void,
             size: data.len() as size_t,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -65,4 +65,10 @@ pub trait SchedulerDriver {
         &self,
         offer_id: &proto::OfferID,
         filters: &proto::Filters) -> i32;
+
+    fn launch_tasks(
+        &self,
+        offer_id: &proto::OfferID,
+        tasks: &Vec<&proto::TaskInfo>,
+        filters: &proto::Filters) -> i32;
 }


### PR DESCRIPTION
This also modifies the test scheduler to launch sleep tasks instead of declining every offer.
Towards completion of #9.
